### PR TITLE
maintenance: stop using dune pre-processing, use github actions

### DIFF
--- a/.github/workflows/ocaml-ci.yml
+++ b/.github/workflows/ocaml-ci.yml
@@ -1,0 +1,43 @@
+name: Build and test
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  ocaml-test:
+    name: Ocaml tests
+    runs-on: ubuntu-20.04
+    env:
+      package: "crc"
+
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Pull configuration from xs-opam
+        run: |
+          curl --fail --silent https://raw.githubusercontent.com/xapi-project/xs-opam/master/tools/xs-opam-ci.env | cut -f2 -d " " > .env
+
+      - name: Load environment file
+        id: dotenv
+        uses: falti/dotenv-action@v0.2.7
+
+      - name: Use ocaml
+        uses: ocaml/setup-ocaml@v1
+        with:
+          ocaml-version: ${{ steps.dotenv.outputs.ocaml_version_full }}
+          opam-repository: ${{ steps.dotenv.outputs.repository }}
+
+      - name: Install dependencies
+        run: |
+          opam pin add . --no-action
+          opam depext -u ${{ env.package }}
+          opam install ${{ env.package }} --deps-only --with-test -v
+
+      - name: Build
+        run: opam exec -- make build
+
+      - name: Build tests
+        run: opam exec -- make test

--- a/lib/dune
+++ b/lib/dune
@@ -1,18 +1,8 @@
-(* -*- tuareg -*- *)
-
-let coverage_rewriter =
-  let bisect = Jbuild_plugin.V1.run_and_read_lines "echo ${BISECT_ENABLE}"
-    |> String.concat ""
-  in
-  if bisect = "YES" then "bisect_ppx -conditional" else ""
-
-let () = Printf.ksprintf Jbuild_plugin.V1.send {|
 (library
   (name crc)
   (public_name crc)
   (flags (:standard))
   (c_names crc_stubs)
   (libraries cstruct)
-  (preprocess (pps ppx_deriving_rpc ppx_sexp_conv %s))
+  (preprocess (pps ppx_deriving_rpc ppx_sexp_conv))
 )
-|} coverage_rewriter

--- a/test/dune
+++ b/test/dune
@@ -1,22 +1,12 @@
-(* -*- tuareg -*- *)
-
-let coverage_rewriter =
-  let bisect = Jbuild_plugin.V1.run_and_read_lines "echo ${BISECT_ENABLE}"
-    |> String.concat ""
-  in
-  if bisect = "YES" then "bisect_ppx -conditional" else ""
-
-let () = Printf.ksprintf Jbuild_plugin.V1.send {|
 (executable
   (name crc_test)
   (flags (:standard))
   (libraries ounit2 crc)
-  (preprocess (pps ppx_deriving_rpc ppx_sexp_conv %s))
+  (preprocess (pps ppx_deriving_rpc ppx_sexp_conv))
 )
 
 (alias
   (name runtest)
   (deps (:x crc_test.exe))
-  (action (run %%{x} -runner sequential))
+  (action (run %{x} -runner sequential))
 )
-|} coverage_rewriter


### PR DESCRIPTION
It's deprecated, there are better ways to generate coverage and it
produces warnings with ocaml 4.14

Successful run can be seen here: https://github.com/psafont/ocaml-crc/runs/6108818616