### PR TITLE
Remove dependency on ppxes

### DIFF
--- a/crc.opam
+++ b/crc.opam
@@ -12,8 +12,6 @@ depends: [
   "cstruct" {>= "1.0.1"}
   "ounit2" {with-test}
   "odoc" {with-doc}
-  "ppx_deriving_rpc"
-  "ppx_sexp_conv" {>= "v0.11.0"}
 ]
 build: [[ "dune" "build" "-p" name ]]
 run-test: [[ "dune" "runtest" "-p" name "-j" jobs ]]

--- a/lib/dune
+++ b/lib/dune
@@ -4,5 +4,4 @@
   (flags (:standard))
   (c_names crc_stubs)
   (libraries cstruct)
-  (preprocess (pps ppx_deriving_rpc ppx_sexp_conv))
 )

--- a/test/dune
+++ b/test/dune
@@ -2,7 +2,6 @@
   (name crc_test)
   (flags (:standard))
   (libraries ounit2 crc)
-  (preprocess (pps ppx_deriving_rpc ppx_sexp_conv))
 )
 
 (alias


### PR DESCRIPTION
I don't know why they were used to preprocess the binaries, but they are not needed anymore.